### PR TITLE
fix: 修复了 Java API 图片路径含有中文调用失败的 Bug

### DIFF
--- a/api/java/Ocr.java
+++ b/api/java/Ocr.java
@@ -1,6 +1,3 @@
-// from: https://github.com/jerrylususu/PaddleOCR-json-java-api
-
-
 package org.example;
 
 import com.google.gson.Gson;
@@ -9,7 +6,84 @@ import com.google.gson.annotations.SerializedName;
 import java.io.*;
 import java.nio.charset.Charset;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
+import java.io.FilterWriter;
+import java.io.IOException;
+import java.io.Writer;
+
+// from: https://github.com/soot-oss/soot/blob/3966f565db6dc2882c3538ffc39e44f4c14b5bcf/src/main/java/soot/util/EscapedWriter.java
+/*-
+ * #%L
+ * Soot - a J*va Optimization Framework
+ * %%
+ * Copyright (C) 1997 - 1999 Raja Vallee-Rai
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+/**
+ * A FilterWriter which catches to-be-escaped characters (<code>\\unnnn</code>) in the input and substitutes their escaped
+ * representation. Used for Soot output.
+ */
+class EscapedWriter extends FilterWriter {
+    /** Convenience field containing the system's line separator. */
+    public final String lineSeparator = System.getProperty("line.separator");
+    private final int cr = lineSeparator.charAt(0);
+    private final int lf = (lineSeparator.length() == 2) ? lineSeparator.charAt(1) : -1;
+
+    /** Constructs an EscapedWriter around the given Writer. */
+    public EscapedWriter(Writer fos) {
+        super(fos);
+    }
+
+    private final StringBuffer mini = new StringBuffer();
+
+    /** Print a single character (unsupported). */
+    public void print(int ch) throws IOException {
+        write(ch);
+        throw new RuntimeException();
+    }
+
+    /** Write a segment of the given String. */
+    public void write(String s, int off, int len) throws IOException {
+        for (int i = off; i < off + len; i++) {
+            write(s.charAt(i));
+        }
+    }
+
+    /** Write a single character. */
+    public void write(int ch) throws IOException {
+        if (ch >= 32 && ch <= 126 || ch == cr || ch == lf || ch == ' ') {
+            super.write(ch);
+            return;
+        }
+
+        mini.setLength(0);
+        mini.append(Integer.toHexString(ch));
+
+        while (mini.length() < 4) {
+            mini.insert(0, "0");
+        }
+
+        mini.insert(0, "\\u");
+        for (int i = 0; i < mini.length(); i++) {
+            super.write(mini.charAt(i));
+        }
+    }
+}
 
 enum OcrCode {
     @SerializedName("100")
@@ -141,7 +215,12 @@ public class Ocr implements AutoCloseable {
         if (!p.isAlive()) {
             throw new RuntimeException("OCR进程已经退出");
         }
-        writer.write(imgFile.toString());
+        Map<String, String> reqJson = new HashMap<>();
+        reqJson.put("image_dir", imgFile.toString());
+        StringWriter sw = new StringWriter();
+        EscapedWriter ew = new EscapedWriter(sw);
+        gson.toJson(reqJson, ew);
+        writer.write(sw.getBuffer().toString());
         writer.write("\r\n");
         writer.flush();
         String resp = reader.readLine();


### PR DESCRIPTION
根据 https://github.com/hiroi-sora/PaddleOCR-json/releases/tag/v1.2.1_alpha_1 的推荐，将图片路径传递方式从直接传 UTF8 字符串修改为传 ASCII-escpaed JSON。