### PR TITLE
fix: 调整node api代码以兼容低版本nodejs

### DIFF
--- a/api/node.js/OCR.js
+++ b/api/node.js/OCR.js
@@ -17,7 +17,9 @@ if (isMainThread) {
     class OCR extends Worker {
         #queue
         constructor(path, args, options, debug) {
-            path ||= 'PaddleOCR_json.exe';
+            if (!path) {
+                path = 'PaddleOCR_json.exe';
+            }
             debug = !!debug;
             super(__filename, {
                 workerData: { path, args, options, debug },
@@ -37,7 +39,7 @@ if (isMainThread) {
                 const queue = this.#queue;
                 obj = Object.assign({}, obj);
                 if (obj.image_dir === null) obj.image_dir = 'clipboard'
-                else obj.image_dir &&= path_resolve(obj.image_dir);
+                else obj.image_dir = path_resolve(obj.image_dir);
                 queue.push(() => new Promise((res_) => {
                     super.once('message', (data) => (res({
                         code: data.code,

--- a/api/node.js/app.js
+++ b/api/node.js/app.js
@@ -3,7 +3,7 @@ const ocr = new OCR('PaddleOCR_json.exe', [], {
     cwd: './PaddleOCR-json'
 }, false);
 
-const fs = require('fs/promises');
+const fs = require('fs').promises;
 
 const mime = require('mime');
 const imgMime = new Set(['bmp', 'jpeg', 'png', 'pbm', 'pgm', 'ppm', 'ras', 'tiff', 'exr', 'jp2'].map((v) => mime.getType(v)));


### PR DESCRIPTION
示例的nodejs 代码当中用了一些比较新的语法还有库，这些只在Node15之后才被支持，因此我调整了一下以兼容旧版本nodejs