### PR TITLE
docs: 补充 Java API 对 1.3 的支持说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ ocr.flush({ image_path: 'path/to/test/img' })
 
 ### 其他API
 
-`PowerShell`、`Java`、`Rust` 等API尚未兼容 v1.3 测试版本。如有需要，请用 [v1.2.1](https://github.com/hiroi-sora/PaddleOCR-json/tree/backups/1.2.1/new_builds) 版本。
+[`Java API`](https://github.com/jerrylususu/PaddleOCR-json-java-api) 已增加对 v1.3 版本的支持。`PowerShell`、`Rust` 等API尚未兼容 v1.3 测试版本。如有需要，请用 [v1.2.1](https://github.com/hiroi-sora/PaddleOCR-json/tree/backups/1.2.1/new_builds) 版本。
 
 ### 更多语言API
 


### PR DESCRIPTION
之前我自己的 repo 里也收到了关于 1.3 版本适配的 [issue](https://github.com/jerrylususu/PaddleOCR-json-java-api/issues/5)，趁着周末把 1.3 版本的支持[补充了](https://github.com/jerrylususu/PaddleOCR-json-java-api/commit/1a84e3f1397f023b9b853800649fe9b9e7caa719)，因此也更新下文档。另外似乎 repo 里 Java API 的链接和文件都不见了？这里先把链接补上，文件后续看 maintainer 是否要再添加进来吧。

