### PR TITLE
add .net api

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ ocr.flush({ image_path: 'path/to/test/img' })
 
 [资源目录](https://github.com/jerrylususu/PaddleOCR-json-java-api)
 
+### 5. .NET API
+
+[资源目录](https://github.com/aki-0929/PaddleOCRJson.NET)
+
 
 ### 其他API
 


### PR DESCRIPTION
感谢作者的奉献.
最近写东西用到paddle-ocr, 发现其他.net集成都比较繁杂.
最近从[Umi-OCR](https://github.com/hiroi-sora/Umi-OCR)了解到作者开发的[PaddleOCR-json](https://github.com/hiroi-sora/PaddleOCR-json)随之体验了一下, 非常方便简洁, 所以对此库进行封装以方便各位打工人使用.