### PR TITLE
Linux移植基础配置

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -3,7 +3,14 @@ cmake_minimum_required(VERSION 3.14)
 
 option(WITH_MKL        "Compile demo with MKL/OpenBlas support, default use MKL."       ON)
 option(WITH_GPU        "Compile demo with GPU/CPU, default use CPU."                    OFF)
-option(WITH_STATIC_LIB "Compile demo with static/shared library, default use static."   ON)
+if (UNIX AND NOT APPLE) # Linux
+  # 在Linux环境下使用 `WITH_STATIC_LIB=ON` 时无法编译
+  # https://github.com/PaddlePaddle/PaddleOCR/issues/10602
+  # 这里就直接强行设置成 `OFF` 了
+  set(WITH_STATIC_LIB OFF)
+else ()
+  option(WITH_STATIC_LIB "Compile demo with static/shared library, default use static."   ON)
+endif ()
 option(WITH_TENSORRT "Compile demo with TensorRT."   OFF)
 
 SET(PADDLE_LIB "" CACHE PATH "Location of libraries")
@@ -44,7 +51,13 @@ if (WIN32)
   find_package(OpenCV REQUIRED PATHS ${OPENCV_DIR}/build/ NO_DEFAULT_PATH)
 
 else ()
-  find_package(OpenCV REQUIRED PATHS ${OPENCV_DIR}/share/OpenCV NO_DEFAULT_PATH)
+  # 如果变量 `OPENCV_DIR` 的值不为空（或者默认值），则使用其给出的OpenCV路径
+  if (DEFINED ${OPENCV_DIR})
+    find_package(OpenCV REQUIRED PATHS ${OPENCV_DIR}/share/OpenCV NO_DEFAULT_PATH)
+  # 反之则让CMake自动寻找OpenCV
+  else ()
+    find_package(OpenCV REQUIRED)
+  endif ()
   include_directories("${PADDLE_LIB}/paddle/include")
   link_directories("${PADDLE_LIB}/paddle/lib")
 endif ()
@@ -71,7 +84,10 @@ else()
     if(WITH_MKL)
         set(FLAG_OPENMP "-fopenmp")
     endif()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -o3 ${FLAG_OPENMP} -std=c++11")
+    # 在Linux环境下使用 `-g -o3` 无法编译
+    # https://github.com/PaddlePaddle/PaddleOCR/issues/4654#issuecomment-977398981
+    # set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -o3 ${FLAG_OPENMP} -std=c++11")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FLAG_OPENMP} -std=c++11")
     set(CMAKE_STATIC_LIBRARY_PREFIX "")
     message("cmake cxx flags" ${CMAKE_CXX_FLAGS})
 endif()

--- a/cpp/src/task_linux.cpp
+++ b/cpp/src/task_linux.cpp
@@ -1,0 +1,31 @@
+// Linux 平台的任务处理代码
+
+#if defined(_LINUX) || defined(__linux__)
+
+#include <iostream>
+
+#include "include/paddleocr.h"
+#include "include/args.h"
+#include "include/task.h"
+
+// #include <平台相关的库>
+
+namespace PaddleOCR
+{
+    cv::Mat Task::imread_u8(std::string pathU8, int flag){
+        std::cerr << "PaddleOCR::Task::imread_u8() stub\n";
+        return cv::Mat();
+    }
+
+    cv::Mat Task::imread_clipboard(int flag){
+        std::cerr << "PaddleOCR::Task::imread_clipboard() stub\n";
+        return cv::Mat();
+    }
+
+    int Task::socket_mode(){
+        std::cerr << "PaddleOCR::Task::socket_mode() stub\n";
+        return 0;
+    }
+}
+
+#endif


### PR DESCRIPTION
感谢作者的奉献。最近才发现Umi-OCR 和这个项目，加上我想在linux上部署Umi-OCR。就由我来开个头吧。

这个PR只是更新了一下`CMakeLists.txt`并加上了一个`task_linux.cpp`的模板。还没有写实际的功能。不过已经可以在linux下编译了（我只测试了ubuntu 22.04）。

**我建议先把这个PR和所有linux相关的PR都merge到一个单独的branch里，等linux相关的主要功能完成后再全部merge回main**

下面附上运行的输出
我用的预测库是`manylinux_cpu_avx_mkl_gcc8.2`
```
LD_LIBRARY_PATH=/path/to/deps ../build/ppocr -config_path=./models/configs.txt -image_path=./data/Screenshot_2024-05-19_005523.jpg
PaddleOCR-json v1.3.1 dev
Load config from [./models/configs.txt] : No valid config found.
---    fused 0 elementwise_add with relu activation
---    fused 0 elementwise_add with tanh activation
---    fused 0 elementwise_add with leaky_relu activation
---    fused 0 elementwise_add with swish activation
---    fused 0 elementwise_add with hardswish activation
---    fused 0 elementwise_add with sqrt activation
---    fused 0 elementwise_add with abs activation
---    fused 0 elementwise_add with clip activation
---    fused 0 elementwise_add with gelu activation
---    fused 0 elementwise_add with relu6 activation
---    fused 0 elementwise_add with sigmoid activation
---    fused 0 elementwise_sub with relu activation
---    fused 0 elementwise_sub with tanh activation
---    fused 0 elementwise_sub with leaky_relu activation
---    fused 0 elementwise_sub with swish activation
---    fused 0 elementwise_sub with hardswish activation
---    fused 0 elementwise_sub with sqrt activation
---    fused 0 elementwise_sub with abs activation
---    fused 0 elementwise_sub with clip activation
---    fused 0 elementwise_sub with gelu activation
---    fused 0 elementwise_sub with relu6 activation
---    fused 0 elementwise_sub with sigmoid activation
---    fused 0 elementwise_mul with relu activation
---    fused 0 elementwise_mul with tanh activation
---    fused 0 elementwise_mul with leaky_relu activation
---    fused 0 elementwise_mul with swish activation
---    fused 0 elementwise_mul with hardswish activation
---    fused 0 elementwise_mul with sqrt activation
---    fused 0 elementwise_mul with abs activation
---    fused 0 elementwise_mul with clip activation
---    fused 0 elementwise_mul with gelu activation
---    fused 0 elementwise_mul with relu6 activation
---    fused 0 elementwise_mul with sigmoid activation
---    fused 0 elementwise_add with relu activation
---    fused 0 elementwise_add with tanh activation
---    fused 0 elementwise_add with leaky_relu activation
---    fused 0 elementwise_add with swish activation
---    fused 0 elementwise_add with hardswish activation
---    fused 0 elementwise_add with sqrt activation
---    fused 0 elementwise_add with abs activation
---    fused 0 elementwise_add with clip activation
---    fused 0 elementwise_add with gelu activation
---    fused 0 elementwise_add with relu6 activation
---    fused 0 elementwise_add with sigmoid activation
---    fused 0 elementwise_sub with relu activation
---    fused 0 elementwise_sub with tanh activation
---    fused 0 elementwise_sub with leaky_relu activation
---    fused 0 elementwise_sub with swish activation
---    fused 0 elementwise_sub with hardswish activation
---    fused 0 elementwise_sub with sqrt activation
---    fused 0 elementwise_sub with abs activation
---    fused 0 elementwise_sub with clip activation
---    fused 0 elementwise_sub with gelu activation
---    fused 0 elementwise_sub with relu6 activation
---    fused 0 elementwise_sub with sigmoid activation
---    fused 0 elementwise_mul with relu activation
---    fused 0 elementwise_mul with tanh activation
---    fused 0 elementwise_mul with leaky_relu activation
---    fused 0 elementwise_mul with swish activation
---    fused 0 elementwise_mul with hardswish activation
---    fused 0 elementwise_mul with sqrt activation
---    fused 0 elementwise_mul with abs activation
---    fused 0 elementwise_mul with clip activation
---    fused 0 elementwise_mul with gelu activation
---    fused 0 elementwise_mul with relu6 activation
---    fused 0 elementwise_mul with sigmoid activation
OCR single image mode. Path: ./data/Screenshot_2024-05-19_005523.jpg
OCR init completed.
PaddleOCR::Task::imread_u8() stub
{"code":0,"data":""}
```