### PR TITLE
[Platform/Linux] 实现socket_mode + 一点文档和脚本的更新

### DIFF
--- a/cpp/src/task_linux.cpp
+++ b/cpp/src/task_linux.cpp
@@ -9,16 +9,24 @@
 #include "include/args.h"
 #include "include/task.h"
 
-// #include <平台相关的库>
+// 套接字
+#include <unistd.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+
+#undef INVALID_SOCKET
+#define INVALID_SOCKET -1
+
 
 namespace PaddleOCR
 {
     // 代替cv imread，接收utf-8字符串传入，返回Mat。
     cv::Mat Task::imread_u8(std::string pathU8, int flag)
     {
-        if (pathU8 == "clipboard") { // 若为剪贴板任务 
+        // 若为剪贴板任务
+        if (pathU8 == "clipboard")
             return imread_clipboard(flag);
-        }
         
         std::ifstream fileInput(pathU8, std::ios::binary);
         // 路径不存在且无法输出
@@ -42,7 +50,7 @@ namespace PaddleOCR
             return cv::Mat();
         }
         
-        // 解码内存数据，变成cv::Mat数据 
+        // 解码内存数据，变成cv::Mat数据
         cv::_InputArray array(buffer, fileLength);
         cv::Mat image = cv::imdecode(array, flag);
         // 释放buffer空间必须放在 cv::imdecode() 之后，
@@ -68,7 +76,129 @@ namespace PaddleOCR
     
     int Task::socket_mode()
     {
-        std::cerr << "PaddleOCR::Task::socket_mode() stub\n";
+        // 创建套接字，协议族为TCP/IP
+        int socketFd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+        if (socketFd == INVALID_SOCKET)
+        {
+            std::cerr << "Failed to create socket." << std::endl;
+            close(socketFd);
+            return -1;
+        }
+        
+        // 配置地址和端口号
+        struct sockaddr_in socketAddr;
+        // 地址族：IPv4
+        socketAddr.sin_family = AF_INET;
+        // IP地址模式：本地环回/任何可用
+        socketAddr.sin_addr.s_addr = (FLAGS_addr=="loopback" ? htonl(INADDR_LOOPBACK) : INADDR_ANY);
+        // 端口号
+        socketAddr.sin_port = htons(FLAGS_port);
+        
+        // 绑定地址和端口号到套接字句柄socketFd
+        if (bind(socketFd, (struct sockaddr*)&socketAddr, sizeof(socketAddr)) == INVALID_SOCKET)
+        {
+            std::cerr << "Failed to bind address." << std::endl;
+            close(socketFd);
+            return -1;
+        }
+        
+        // 将套接字socketFd设为监听状态，只允许1个客户端排队连接
+        if (listen(socketFd, 1) == INVALID_SOCKET)
+        {
+            std::cerr << "Failed to set listen." << std::endl;
+            close(socketFd);
+            return -1;
+        }
+        
+        // 获取服务端实际ip和端口
+        struct sockaddr_in serverAddr;
+        socklen_t len = sizeof(serverAddr);
+        if (getsockname(socketFd, (sockaddr*)&serverAddr, &len) == INVALID_SOCKET)
+        {
+            std::cerr << "Failed to get sockname." << std::endl;
+            close(socketFd);
+            return -1;
+        }
+        // 获取端口号 & ip地址
+        int serverPort = ntohs(serverAddr.sin_port);
+        char* serverIp = inet_ntoa(socketAddr.sin_addr);
+        std::cout << "Socket init completed. " << serverIp << ":" << serverPort << std::endl;
+        
+        
+        // 循环等待接收连接
+        while (true)
+        {
+            // 接受连接请求
+            struct sockaddr_in clientAddr;
+            socklen_t clientAddrLen = sizeof(clientAddr);
+            int clientFd = accept(socketFd, (sockaddr*)&clientAddr, &clientAddrLen);
+            if (clientFd == INVALID_SOCKET)
+            {
+                std::cerr << "Failed to accept connection." << std::endl;
+                continue;
+            }
+            
+            // 获取客户端实际ip和端口
+            char* clientIp = inet_ntoa(clientAddr.sin_addr);
+            int clientPort = ntohs(clientAddr.sin_port);
+            std::cerr << "Client connected. IP address: " << clientIp << ":" << clientPort << std::endl;
+            
+            // 接收任意长度数据
+            std::string strIn; // 接收数据存放处
+            char buffer[1024]; // 缓冲区
+            int bytesRecv = 0;
+            while (true)
+            {
+                bytesRecv = recv(clientFd, buffer, sizeof(buffer), 0);
+                
+                // 没收到数据，可能客户端断开连接或连接错误
+                if (bytesRecv <= 0)
+                    break;
+                
+                // 将本次接收到的数据追加到存放处末尾
+                strIn.append(buffer, bytesRecv);
+                
+                // 到达末尾符，认为数据已全部接收完毕
+                if (buffer[bytesRecv - 1] == '\0' || buffer[bytesRecv - 1] == '\n')
+                    break;
+            }
+            
+            // 没有接收到数据 | 接收到0字节
+            if (bytesRecv <= 0)
+            {
+                std::cerr << "Failed to receive data." << std::endl;
+                close(clientFd);
+                continue;
+            }
+            std::cerr << "Get string. Length: " << strIn.length() << std::endl;
+            
+            
+            // =============== OCR开始 ===============
+            set_state(); // 初始化状态
+            // 获取ocr结果
+            std::string strOut = run_ocr(strIn);
+            // ocr结束，关闭连接，退出循环
+            if (is_exit)
+            {
+                close(clientFd);
+                break;
+            }
+            // =============== OCR完毕 ===============
+            
+            // 发送数据
+            std::cout << strOut << std::endl;
+            int bytesSent = send(clientFd, strOut.c_str(), strlen(strOut.c_str()), 0);
+            // 没有发送出数据 | 发送出0字节
+            if (bytesSent <= 0)
+                std::cerr << "Failed to send data." << std::endl;
+            
+            // 关闭连接
+            close(clientFd);
+        }
+        
+        // 关闭套接字
+        close(socketFd);
+        
         return 0;
     }
 }

--- a/cpp/tools/linux_build.sh
+++ b/cpp/tools/linux_build.sh
@@ -6,9 +6,18 @@ cd $SCRIPT_DIR/..
 
 # 一些CMake的变量
 MODE=Release
-PADDLE_LIB="./.source/paddle_inference"
+PADDLE_LIB="$(pwd)/$(ls -d .source/*paddle_inference*/ | head -n1)"
+
+echo "MODE: $MODE"
+echo "PADDLE_LIB: $PADDLE_LIB"
 
 # 构建 & 编译项目
 mkdir -p build
-cmake -S . -B build/ -DPADDLE_LIB=$PADDLE_LIB -DCMAKE_BUILD_TYPE=$MODE
+
+# 如果build文件夹不是一个CMake工程，则构建工程文件夹（第一次运行）
+if [ ! -d "build/CMakeFiles/" ]; then
+    cmake -S . -B build/ -DPADDLE_LIB=$PADDLE_LIB -DCMAKE_BUILD_TYPE=$MODE
+fi
+
+# 编译
 cmake --build build/ --config=$MODE

--- a/cpp/tools/linux_build.sh
+++ b/cpp/tools/linux_build.sh
@@ -16,8 +16,8 @@ mkdir -p build
 
 # 如果build文件夹不是一个CMake工程，则构建工程文件夹（第一次运行）
 if [ ! -d "build/CMakeFiles/" ]; then
-    cmake -S . -B build/ -DPADDLE_LIB=$PADDLE_LIB -DCMAKE_BUILD_TYPE=$MODE
+    cmake -S . -B build/ -DPADDLE_LIB="$PADDLE_LIB" -DCMAKE_BUILD_TYPE="$MODE"
 fi
 
 # 编译
-cmake --build build/ --config=$MODE
+cmake --build build/ --config="$MODE"

--- a/cpp/tools/linux_run.sh
+++ b/cpp/tools/linux_run.sh
@@ -21,8 +21,11 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd $SCRIPT_DIR/../.source
 
 # 从预测库里找出所有动态库文件夹
-PADDLE_LIB="paddle_inference"
+PADDLE_LIB="$(pwd)/$(ls -d *paddle_inference*/ | head -n1)"
 LIBS="$(find $PADDLE_LIB -name 'lib' -type d | paste -sd ':' -)"
+
+echo "PADDLE_LIB: $PADDLE_LIB"
+echo "LIBS: $LIBS"
 
 # 运行PaddleOCR-json
 LD_LIBRARY_PATH=$LIBS ../build/ppocr \

--- a/cpp/tools/linux_run.sh
+++ b/cpp/tools/linux_run.sh
@@ -8,7 +8,7 @@ fi
 
 # 将第一个argument转成绝对路径
 if [[ "$1" = /* ]]; then # 绝对路径
-    IMG_PATH=$1
+    IMG_PATH="$1"
 else # 相对路径
     IMG_PATH="$(pwd)/$1"
 fi
@@ -18,7 +18,7 @@ echo "输入图片路径：$IMG_PATH"
 
 # 获取当前脚本路径并去到 "cpp/.source" 文件夹下
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-cd $SCRIPT_DIR/../.source
+cd "$SCRIPT_DIR/../.source"
 
 # 从预测库里找出所有动态库文件夹
 PADDLE_LIB="$(pwd)/$(ls -d *paddle_inference*/ | head -n1)"
@@ -28,6 +28,6 @@ echo "PADDLE_LIB: $PADDLE_LIB"
 echo "LIBS: $LIBS"
 
 # 运行PaddleOCR-json
-LD_LIBRARY_PATH=$LIBS ../build/ppocr \
+LD_LIBRARY_PATH="$LIBS" ../build/ppocr \
     -config_path=./models/config_chinese.txt \
-    -image_path=$IMG_PATH
+    -image_path="$IMG_PATH"


### PR DESCRIPTION
Linux移植第三弹：

* 实现socket_mode，整体的api跟Windows的差不多，改一点就能用了
* 更新linux文档有关AVX的部分
* 更新linux脚本，修复两个bug

linux python api 已经可以用了
```sh
$ LD_LIBRARY_PATH=$LIBS python3 demo1.py 
初始化OCR成功，进程号为133385

测试图片路径：/mnt/c/Users/user/Dev/PaddleOCR-json/api/python/test.jpg

示例1-图片路径识别结果（原始信息）：
{'code': 100, 'data': [{'box': [[27, 31], [526, 33], [526, 61], [27, 59]], 'score': 0.9595203399658203, 'text': 'PaddleOCR旨在打造一套丰富、领先、'}, {'box': [[31, 87], [305, 87], [305, 110], [31, 110]], 'score': 0.9535067677497864, 'text': '且实用的OCR工具库'}]}

示例1-图片路径识别结果（格式化输出）：
1-置信度：0.96，文本：PaddleOCR旨在打造一套丰富、领先、
2-置信度：0.95，文本：且实用的OCR工具库

# 这里错误是因为 imread_clipboard() 还没写
示例2-剪贴板识别结果：
图片识别失败。错误码：0，错误信息：

示例3-字节流识别结果：
1-置信度：0.96，文本：PaddleOCR旨在打造一套丰富、领先、
2-置信度：0.95，文本：且实用的OCR工具库

示例4-PIL Image 识别结果：
1-置信度：0.96，文本：PaddleOCR旨在打造一套丰富、领先、
2-置信度：0.88，文本：且实用的OCR工具库
```