### PR TITLE
[Platform/Linux] 修复一些bug + 一点文档和脚本更新

### DIFF
--- a/api/python/PPOCR_api.py
+++ b/api/python/PPOCR_api.py
@@ -18,13 +18,11 @@ class PPOCR_pipe:  # 调用OCR（管道模式）
         `argument`: 启动参数，字典`{"键":值}`。参数说明见 https://github.com/hiroi-sora/PaddleOCR-json
         """
         cwd = os.path.abspath(os.path.join(exePath, os.pardir))  # 获取exe父文件夹
+        cmds = [exePath]
         # 处理启动参数
         if not argument == None:
             for key, value in argument.items():
-                if isinstance(value, str):  # 字符串类型的值加双引号
-                    exePath += f' --{key}="{value}"'
-                else:
-                    exePath += f" --{key}={value}"
+                cmds += [f'--{key}', str(value)] # Popen() 要求输入list里所有的元素都是 str 或 bytes
         # 设置子进程启用静默模式，不显示控制台窗口
         self.ret = None
         startupinfo = None
@@ -35,7 +33,7 @@ class PPOCR_pipe:  # 调用OCR（管道模式）
             )
             startupinfo.wShowWindow = subprocess.SW_HIDE
         self.ret = subprocess.Popen(  # 打开管道
-            exePath,
+            cmds,
             cwd=cwd,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,

--- a/api/python/demo1.py
+++ b/api/python/demo1.py
@@ -7,7 +7,7 @@ from PPOCR_api import GetOcrApi
 import os
 
 # 测试图片路径
-TestImagePath = f"{os.path.dirname(os.path.abspath(__file__))}\\test.jpg"
+TestImagePath = os.path.join(os.path.dirname(os.path.abspath(__file__)), "test.jpg")
 
 # 初始化识别器对象，传入 PaddleOCR-json.exe 的路径。请改成你自己的路径
 ocr = GetOcrApi(r"D:\……\PaddleOCR-json.exe")

--- a/api/python/demo1.py
+++ b/api/python/demo1.py
@@ -48,7 +48,7 @@ if Image:
     pilImage = Image.open(TestImagePath)
     # Image 对象转为 字节流
     buffered = BytesIO()
-    pilImage.save(buffered, format="JPEG")
+    pilImage.save(buffered, format="PNG")
     imageBytes = buffered.getvalue()
     # 送入OCR
     res = ocr.runBytes(imageBytes)

--- a/api/python/demo2.py
+++ b/api/python/demo2.py
@@ -8,7 +8,7 @@ from PPOCR_visualize import visualize
 import os
 
 # 测试图片路径
-TestImagePath = f"{os.path.dirname(os.path.abspath(__file__))}\\test.jpg"
+TestImagePath = os.path.join(os.path.dirname(os.path.abspath(__file__)), "test.jpg")
 
 # 初始化识别器对象，传入 PaddleOCR_json.exe 的路径
 ocr = GetOcrApi(r"D:\MyCode\CppCode\PaddleOCR-json\cpp\build\Release\PaddleOCR-json.exe")

--- a/api/python/demo3.py
+++ b/api/python/demo3.py
@@ -9,12 +9,10 @@ import tbpu
 import os
 
 # 测试图片路径
-TestImagePath = f"{os.path.dirname(os.path.abspath(__file__))}\\test.jpg"
+TestImagePath = os.path.join(os.path.dirname(os.path.abspath(__file__)), "test.jpg")
 
 # 初始化识别器对象，传入 PaddleOCR_json.exe 的路径
-ocr = GetOcrApi(
-    r"D:\MyCode\CppCode\PaddleOCR-json\cpp\build\Release\PaddleOCR-json.exe"
-)
+ocr = GetOcrApi(r"D:\MyCode\CppCode\PaddleOCR-json\cpp\build\Release\PaddleOCR-json.exe")
 print(f"初始化OCR成功，进程号为{ocr.ret.pid}")
 
 # OCR识别图片，获取文本块

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -22,6 +22,20 @@ SET(TENSORRT_DIR "" CACHE PATH "Compile demo with TensorRT")
 set(DEMO_NAME "PaddleOCR-json") 
 
 
+# 检测是否运行在WSL下，如果是则设置compiler flag：-DUNDER_WSL
+if (UNIX AND NOT APPLE) # Linux
+  execute_process (
+    COMMAND "uname" "-a"
+    OUTPUT_VARIABLE UNAME_RESULT
+  )
+  string(STRIP "${UNAME_RESULT}" UNAME_RESULT)
+  if (UNAME_RESULT MATCHES ".*WSL.*")
+    message("Compiling under WSL")
+    add_definitions(-DUNDER_WSL)
+  endif()
+endif ()
+
+
 macro(safe_set_static_flag)
     foreach(flag_var
         CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE

--- a/cpp/README-linux.md
+++ b/cpp/README-linux.md
@@ -1,8 +1,8 @@
 # PaddleOCR-json V1.3 Linux 构建指南
 
-本文档帮助如何在Linux上编译 PaddleOCR-json V1.3 （对应PPOCR v2.6）。推荐给具有一定Linux命令行使用经验的读者。
+本文档帮助如何在Linux上编译 PaddleOCR-json V1.3 （对应PaddleOCR v2.6）。推荐给具有一定Linux命令行使用经验的读者。
 
-本文参考了 PPOCR官方的[编译指南](https://github.com/PaddlePaddle/PaddleOCR/blob/release/2.6/deploy/cpp_infer/readme_ch.md) ，但建议以本文为准。
+本文参考了 PaddleOCR官方的[编译指南](https://github.com/PaddlePaddle/PaddleOCR/blob/release/2.6/deploy/cpp_infer/readme_ch.md) ，但建议以本文为准。
 
 另外，本文将使用Debian/Ubuntu系列linux为例子进行讲解。其他linux发行版的用户请自行替换一些对应的命令（比如apt这类的）。
 
@@ -173,20 +173,20 @@ cmake --build build/
 
 ## 3. 配置 & 运行可执行文件
 
-1. 到这一步，你应该可以在 `build` 文件夹下找到一个叫 `ppocr` 的可执行文件
+1. 到这一步，你应该可以在 `build` 文件夹下找到一个叫 `PaddleOCR-json` 的可执行文件
 
 ```sh
-ls ./build/ppocr
+ls ./build/PaddleOCR-json
 ```
 
 2. 直接运行的话会得到这样一个错误
 
 ```sh
-./build/ppocr
+./build/PaddleOCR-json
 ```
 
 ```
-./build/ppocr: error while loading shared libraries: libiomp5.so: cannot open shared object file: No such file or directory
+./build/PaddleOCR-json: error while loading shared libraries: libiomp5.so: cannot open shared object file: No such file or directory
 ```
 
 > [!NOTE]
@@ -197,7 +197,7 @@ ls ./build/ppocr
 ```sh
 # 从之前的预测库文件夹下找出所有名为 "lib" 的文件夹，然后再把他们用 ":" 字符给串接起来（就是 String.join()）。最后在存到一个变量里面。
 LIBS="$(find $PADDLE_LIB -name 'lib' -type d | paste -sd ':' -)"
-LD_LIBRARY_PATH=$LIBS ./build/ppocr
+LD_LIBRARY_PATH=$LIBS ./build/PaddleOCR-json
 ```
 
 > [!TIP]
@@ -218,9 +218,9 @@ LD_LIBRARY_PATH=$LIBS ./build/ppocr
 ```sh
 # PaddleOCR-json 必须运行在 "module" 文件夹的相同目录下
 cd $MODELS/..
-LD_LIBRARY_PATH=$LIBS ../build/ppocr \
-    -config_path=./models/config_chinese.txt \
-    -image_path=/path/to/image.jpg # 图片的路径
+LD_LIBRARY_PATH=$LIBS ../build/PaddleOCR-json \
+    -config_path="./models/config_chinese.txt" \
+    -image_path="/path/to/image.jpg" # 图片的路径
 ```
 
 > [!TIP]

--- a/cpp/README-linux.md
+++ b/cpp/README-linux.md
@@ -112,7 +112,7 @@ PaddleOCR-json
 5. 最后一步，为了方便之后的使用，设置两个环境变量。
 
 ```sh
-export PADDLE_LIB="$(pwd)/paddle_inference_manylinux_cpu_avx_mkl_gcc8.2"
+export PADDLE_LIB="$(pwd)/$(ls -d *paddle_inference*/ | head -n1)"
 export MODELS="$(pwd)/models"
 ```
 

--- a/cpp/src/task_linux.cpp
+++ b/cpp/src/task_linux.cpp
@@ -177,7 +177,7 @@ namespace PaddleOCR
             set_state(); // 初始化状态
             // 获取ocr结果
             std::string strOut = run_ocr(strIn);
-            // ocr结束，关闭连接，退出循环
+            // 接收到退出指令，关闭连接，退出主循环，結束服务器
             if (is_exit)
             {
                 close(clientFd);

--- a/cpp/src/task_linux.cpp
+++ b/cpp/src/task_linux.cpp
@@ -186,17 +186,7 @@ namespace PaddleOCR
             // =============== OCR完毕 ===============
             
             // 发送数据
-#ifdef UNDER_WSL
-            // 当运行在WSL下时，如果使用 python subprocess.Popen() 来以子进程的形式启动这个程序，
-            // 并且将所有的 stdout 输出导入 subprocess.PIPE 时，
-            // 下面这一行 std::cout 会将整个服务器阻塞。
-            // 于是我们用 CMake 去检测 WSL 并设置这个 UNDER_WSL 的 compiler flag。
-            // 如果在 WSL 下就直接跳过下面这行 std::cout 了。
-            // 在套接字服务器的模式下，其他进程应该直接从套接字里接收数据而非使用 pipe 。
-            // 所以无视下面这行 std::cout 的影响应该不大。
-#else
-            std::cout << strOut << std::endl;
-#endif
+            std::cerr << strOut << std::endl;
             int bytesSent = send(clientFd, strOut.c_str(), strlen(strOut.c_str()), 0);
             // 没有发送出数据 | 发送出0字节
             if (bytesSent <= 0)

--- a/cpp/src/task_linux.cpp
+++ b/cpp/src/task_linux.cpp
@@ -186,7 +186,17 @@ namespace PaddleOCR
             // =============== OCR完毕 ===============
             
             // 发送数据
+#ifdef UNDER_WSL
+            // 当运行在WSL下时，如果使用 python subprocess.Popen() 来以子进程的形式启动这个程序，
+            // 并且将所有的 stdout 输出导入 subprocess.PIPE 时，
+            // 下面这一行 std::cout 会将整个服务器阻塞。
+            // 于是我们用 CMake 去检测 WSL 并设置这个 UNDER_WSL 的 compiler flag。
+            // 如果在 WSL 下就直接跳过下面这行 std::cout 了。
+            // 在套接字服务器的模式下，其他进程应该直接从套接字里接收数据而非使用 pipe 。
+            // 所以无视下面这行 std::cout 的影响应该不大。
+#else
             std::cout << strOut << std::endl;
+#endif
             int bytesSent = send(clientFd, strOut.c_str(), strlen(strOut.c_str()), 0);
             // 没有发送出数据 | 发送出0字节
             if (bytesSent <= 0)

--- a/cpp/src/task_win32.cpp
+++ b/cpp/src/task_win32.cpp
@@ -330,7 +330,7 @@ namespace PaddleOCR
             // =============== OCR完毕 =============== 
 
             // 发送数据
-            std::cout << str_out << std::endl;
+            std::cerr << str_out << std::endl;
             int m = send(client_fd, str_out.c_str(), strlen(str_out.c_str()), 0);
             if (m <= 0) {
                 std::cerr << "Failed to send data." << std::endl;

--- a/cpp/tools/linux_run.sh
+++ b/cpp/tools/linux_run.sh
@@ -28,6 +28,6 @@ echo "PADDLE_LIB: $PADDLE_LIB"
 echo "LIBS: $LIBS"
 
 # 运行PaddleOCR-json
-LD_LIBRARY_PATH="$LIBS" ../build/ppocr \
+LD_LIBRARY_PATH="$LIBS" ../build/PaddleOCR-json \
     -config_path=./models/config_chinese.txt \
     -image_path="$IMG_PATH"

--- a/cpp/tools/linux_run.sh
+++ b/cpp/tools/linux_run.sh
@@ -1,20 +1,14 @@
 #! /bin/bash -e
 
-# 检查第一个argument
-if [ -z "$1" ] ; then
-    echo "用法：./tools/linux_run.sh /图片路径/img.jpg"
-    exit
+# 没有配置参数
+if [ $# -eq 0 ]; then
+    echo "用法：./tools/linux_run.sh [配置参数]"
+    echo "请注意：所有的相对路径都将以 .source 文件夹为基准"
+    exit 0
 fi
 
-# 将第一个argument转成绝对路径
-if [[ "$1" = /* ]]; then # 绝对路径
-    IMG_PATH="$1"
-else # 相对路径
-    IMG_PATH="$(pwd)/$1"
-fi
-
-echo "输入图片路径：$IMG_PATH"
-
+# 获取PaddleOCR-json路径
+EXE_LOCATION="$(pwd)/build/PaddleOCR-json"
 
 # 获取当前脚本路径并去到 "cpp/.source" 文件夹下
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
@@ -28,6 +22,5 @@ echo "PADDLE_LIB: $PADDLE_LIB"
 echo "LIBS: $LIBS"
 
 # 运行PaddleOCR-json
-LD_LIBRARY_PATH="$LIBS" ../build/PaddleOCR-json \
-    -config_path=./models/config_chinese.txt \
-    -image_path="$IMG_PATH"
+LD_LIBRARY_PATH="$LIBS" "$EXE_LOCATION" \
+    "$@"


### PR DESCRIPTION
* 修复 #112 和 #113
* 修复 #114 （给WSL开了特例，具体bug分析请看原issue）
* 在 python api demo 中使用 `os.path.join` 来生成图片文件路径，这样就能生成跨平台路径了
* python api demo1 里面的这行：

https://github.com/hiroi-sora/PaddleOCR-json/blob/763311cb91481917dbae86cac8cc3c1a171d40fe/api/python/demo1.py#L51

它无法保存 RGBA 的图片。既然C++里面已经有处理RGBA转格式的代码了，那我觉得这里直接把 `format` 设置成 `PNG` 就行了。

* 一点linux 文档和脚本的更新