### PR TITLE
更新CMake linux 打包安装流程+文档

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -32,6 +32,9 @@ option(ENABLE_CLIPBOARD         "启用剪贴板功能。默认关闭。"       
 option(ENABLE_REMOTE_EXIT       "启用远程关停服务器命令。默认开启。"  ON)
 option(ENABLE_JSON_IMAGE_PATH   "启用json命令image_path。默认开启。" ON)
 
+# CMake功能相关参数
+option(INSTALL_WITH_TOOLS       "CMake安装时附带工具文件。默认开启。"      ON)
+
 
 # compiler flags
 
@@ -93,6 +96,9 @@ message(STATUS "Features:")
 message(STATUS "    ENABLE_CLIPBOARD: ${ENABLE_CLIPBOARD}")
 message(STATUS "    ENABLE_REMOTE_EXIT: ${ENABLE_REMOTE_EXIT}")
 message(STATUS "    ENABLE_JSON_IMAGE_PATH: ${ENABLE_JSON_IMAGE_PATH}")
+# 输出CMake功能设置
+message(STATUS "CMake Features:")
+message(STATUS "    INSTALL_WITH_TOOLS: ${INSTALL_WITH_TOOLS}")
 
 
 # 加载依赖
@@ -319,20 +325,24 @@ endforeach()
 # CMake TARGET安装路径设置
 # 参考OpenCV：
 # https://cmake.org/cmake/help/latest/variable/CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT.html
-if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+# 如果CMake安装路径为默认
+if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     # 本地编译
-    if(NOT CMAKE_TOOLCHAIN_FILE)
-        if(WIN32)
+    if (NOT CMAKE_TOOLCHAIN_FILE)
+        if (WIN32)
             set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install" CACHE PATH "安装路径" FORCE)
-        else()
-            set(CMAKE_INSTALL_PREFIX "/usr/local" CACHE PATH "安装路径" FORCE)
-        endif()
+        else ()
+            set(CMAKE_INSTALL_PREFIX "/usr/" CACHE PATH "安装路径" FORCE)
+        endif ()
     
     # 其他跨平台编译
-    else()
+    else ()
         set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install" CACHE PATH "安装路径" FORCE)
-    endif()
-endif()
+    endif ()
+endif ()
+
+# 设施安装文件的运行环境路径
+set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 
 # 安装TARGET
 install(
@@ -361,18 +371,21 @@ else ()
         PATTERN "*${CMAKE_SHARED_LIBRARY_SUFFIX}*"
         PATTERN "${DEMO_NAME}*" EXCLUDE
     )
-    # 安装启动脚本和安装脚本
-    install(
-        FILES
-            "${CMAKE_CURRENT_SOURCE_DIR}/tools/linux_dist_tools/run.sh"
-            "${CMAKE_CURRENT_SOURCE_DIR}/tools/linux_dist_tools/install_env.sh"
-        PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
-        DESTINATION "."
-    )
-    # 安装README.txt
-    install(
-        FILES
-            "${CMAKE_CURRENT_SOURCE_DIR}/tools/linux_dist_tools/README.txt"
-        DESTINATION "."
-    )
+    if (INSTALL_WITH_TOOLS)
+        # 安装启动脚本和安装脚本
+        install(
+            FILES
+                "${CMAKE_CURRENT_SOURCE_DIR}/tools/linux_dist_tools/run.sh"
+                "${CMAKE_CURRENT_SOURCE_DIR}/tools/linux_dist_tools/install_env.sh"
+            PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+            DESTINATION "."
+        )
+        # 安装README.txt
+        install(
+            FILES
+                "${CMAKE_CURRENT_SOURCE_DIR}/tools/linux_dist_tools/README.txt"
+            PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ GROUP_WRITE WORLD_READ
+            DESTINATION "."
+        )
+    endif ()
 endif ()

--- a/cpp/README-linux.md
+++ b/cpp/README-linux.md
@@ -177,7 +177,7 @@ cmake --build build/
 | `OPENCV_DIR`   | 库的路径                     |
 | `CUDA_LIB`     | 库的路径                     |
 | `CUDNN_LIB`    | 库的路径                     |
-| `TENSORRT_DIR` | 使用TensorRT编译并设置其路径 |
+| `TENSORRT_DIR` | 使用TensorRT编译并设置其路径  |
 
 > [!NOTE]
 > * `OPENCV_DIR`: Linux下，如果已经安装到系统之中就不用指定了。
@@ -194,6 +194,12 @@ cmake --build build/
 > * `ENABLE_CLIPBOARD`: Linux下没有剪贴板功能，启用了也无法使用。
 > * `ENABLE_REMOTE_EXIT`: 这个参数控制着 “传入 `exit` 关停服务器” 的功能。
 > * `ENABLE_JSON_IMAGE_PATH`: 这个参数控制着 “使用`{"image_path":""}`指定路径” 的功能。
+
+以下是一些CMake功能相关参数。
+
+| 参数名                   | 描述                               |
+| ------------------------ | --------------------------------- |
+| `INSTALL_WITH_TOOLS`     | CMake安装时附带工具文件。默认开启。  |
 
 #### 关于剪贴板读取
 
@@ -291,7 +297,12 @@ LD_LIBRARY_PATH=$LIBS ./build/bin/PaddleOCR-json \
 sudo cmake --install build
 ```
 
-CMake会将 `build` 文件夹下的可执行文件和运行库给安装到系统文件夹 `/usr/local` 下，这样你就可以直接用 `PaddleOCR-json` 来调用这个软件了。
+CMake会将 `build` 文件夹下的可执行文件和运行库给安装到系统文件夹 `/usr/` 下，这样你就可以直接用 `PaddleOCR-json` 来调用这个软件了。
 
 如果你希望安装到指定位置，你可以为上面这条命令加上参数 `--prefix /安装路径/` 来指定一个安装路径。比如 `--prefix build/install` 会将所有的文件都安装到 `build/install` 文件夹下。
 
+> [!TIP]
+> 在Linux下安装时，CMake会额外安装一些工具脚本和文档以方便用户直接使用（[就是 `linux_dist_tools/` 文件夹下的东西](./tools/linux_dist_tools/)）。这个功能可以帮助开发者更方便的打包软件。但是，如果你希望将PaddleOCR-json安装到系统文件夹里，你则不需要这些工具文件。你可以通过关闭CMake参数 `INSTALL_WITH_TOOLS` 来禁用这些工具文件的安装。
+
+> [!TIP]
+> CMake在安装PaddleOCR-json时，会将所有在 `build/bin` 文件夹下的共享依赖库给复制到安装目录的 `lib` 文件夹下。但是，Linux的很多共享库是被拆分在系统文件夹里的（比如 `/usr/lib/` ）。CMake无法自动找到这些共享依赖库。如果你需要将PaddleOCR-json打包成一个无依赖的软件，你需要手动将所有在系统文件夹里的共享依赖库给复制到 `build/bin` 文件夹下。这样一来CMake就可以在安装时将完整的依赖共享库一起打包了。


### PR DESCRIPTION
这个PR主要是添加了一个CMake参数 `INSTALL_WITH_TOOLS`。它可以方便开发者去控制在Linux下使用CMake安装时是否要把工具文件一同安装（像 `run.sh`、`install_env.sh`那些）。

如果用户想要用CMake安装PaddleOCR-json到系统文件夹的时候，他们不需要这些工具文件，就可以直接设置 `-DINSTALL_WITH_TOOLS=OFF` 来禁用这个功能。

如果开发者需要将软件打包，则可以开启这个给功能。

`INSTALL_WITH_TOOLS` 默认开启。

文档也一并更新了。
