### PR TITLE
修复一些cmake bug与更新文档

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,4 +1,7 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.15...3.30)
+# cmake version range:
+# https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html
+
 project(PaddleOCR-json CXX C)
 
 # 消除CMake Policy CMP0048警告
@@ -114,21 +117,26 @@ message(STATUS "    INSTALL_WITH_TOOLS: ${INSTALL_WITH_TOOLS}")
 # OpenCV
 # 尝试从人工提供的OpenCV路径寻找OpenCV
 # 请提供一个路径包含 "OpenCVConfig.cmake" 或 "opencv-config.cmake"这两个文件
+# 或者提供 OpenCV 编译后的安装目录
 
 # 由CMake参数提供（-DOPENCV_DIR）
 if(DEFINED OPENCV_DIR AND NOT "${OPENCV_DIR}" STREQUAL "")
     message(STATUS "Setting OPENCV_DIR: ${OPENCV_DIR}")
     find_package(OpenCV PATHS ${OPENCV_DIR} NO_DEFAULT_PATH)
+    set(CUSTOM_OPENCV_DIR ${OPENCV_DIR})
 elseif(DEFINED OpenCV_DIR AND NOT "${OpenCV_DIR}" STREQUAL "")
     message(STATUS "Setting OPENCV_DIR: ${OpenCV_DIR}")
     find_package(OpenCV PATHS ${OpenCV_DIR} NO_DEFAULT_PATH)
+    set(CUSTOM_OPENCV_DIR ${OpenCV_DIR})
 # 由环境变量提供 OPENCV_DIR 或 OpenCV_DIR 提供
 elseif(NOT "$ENV{OPENCV_DIR}" STREQUAL "")
     message(STATUS "Setting OPENCV_DIR: $ENV{OPENCV_DIR}")
     find_package(OpenCV PATHS $ENV{OPENCV_DIR} NO_DEFAULT_PATH)
+    set(CUSTOM_OPENCV_DIR $ENV{OPENCV_DIR})
 elseif(NOT "$ENV{OpenCV_DIR}" STREQUAL "")
     message(STATUS "Setting OPENCV_DIR: $ENV{OpenCV_DIR}")
     find_package(OpenCV PATHS $ENV{OpenCV_DIR} NO_DEFAULT_PATH)
+    set(CUSTOM_OPENCV_DIR $ENV{OpenCV_DIR})
 # 没有提供OpenCV路径，尝试让CMake自己寻找
 else()
     find_package(OpenCV REQUIRED)
@@ -337,10 +345,65 @@ add_executable(${DEMO_NAME} ${SRCS})
 target_link_libraries(${DEMO_NAME} ${DEPS})
 
 
-# 把 PADDLE_LIB 文件夹下的所有共享库找出
-file(GLOB_RECURSE PADDLE_LIB_FILES "${PADDLE_LIB}/*${CMAKE_SHARED_LIBRARY_SUFFIX}*")
-# 然后全部复制到TARGET的输出文件夹里
+# 设置需要安装的共享库
+
+# PaddleOCR，直接找出其路径下所有共享库即可
+message(STATUS "Collecting PaddleOCR shared libraries")
+file(GLOB_RECURSE PADDLE_LIB_FILES "${PADDLE_LIB}/**/*${CMAKE_SHARED_LIBRARY_SUFFIX}*")
 foreach(ITEM ${PADDLE_LIB_FILES})
+    list(APPEND LIBS_TO_INSTALL ${ITEM})
+endforeach()
+
+# OpenCV
+include(cmake/opencv-install-utils.cmake)
+if(DEFINED CUSTOM_OPENCV_DIR AND NOT "${CUSTOM_OPENCV_DIR}" STREQUAL "")
+    message(STATUS "Collecting custom OpenCV shared libraries")
+    set(OPENCV_MISS_LIBS FALSE)
+    
+    # 收集共享库及其符号链接信息
+    collect_opencv_lib(${CUSTOM_OPENCV_DIR} ${CMAKE_SHARED_LIBRARY_SUFFIX} "opencv_core" opencv_core_miss_lib opencv_core_regular opencv_core_symlink)
+    collect_opencv_lib(${CUSTOM_OPENCV_DIR} ${CMAKE_SHARED_LIBRARY_SUFFIX} "opencv_imgcodecs" opencv_imgcodecs_miss_lib opencv_imgcodecs_regular opencv_imgcodecs_symlink)
+    collect_opencv_lib(${CUSTOM_OPENCV_DIR} ${CMAKE_SHARED_LIBRARY_SUFFIX} "opencv_imgproc" opencv_imgproc_miss_lib opencv_imgproc_regular opencv_imgproc_symlink)
+    
+    if(opencv_core_miss_lib OR opencv_imgcodecs_miss_lib OR opencv_imgproc_miss_lib)
+        set(OPENCV_MISS_LIBS TRUE)
+    endif()
+    
+    # 有缺失就尝试opencv_world
+    if(DEFINED OPENCV_MISS_LIBS AND OPENCV_MISS_LIBS)
+        message(STATUS "Missing OpenCV independent shared libraries, try opencv_world")
+        collect_opencv_lib(${CUSTOM_OPENCV_DIR} ${CMAKE_SHARED_LIBRARY_SUFFIX} "opencv_world" opencv_world_miss_lib opencv_world_regular opencv_world_symlink)
+        if(opencv_world_miss_lib)
+            message(FATAL_ERROR "Cannot find OpenCV independent shared libraries or opencv_world. Please make sure your custom OpenCV directory contains the missing libraries.")
+        else()
+            list(APPEND LIBS_TO_INSTALL ${opencv_world_regular})
+            list(JOIN opencv_world_symlink "/" opencv_world_symlink_str)
+            list(APPEND SYMS_TO_INSTALL ${opencv_world_symlink_str})
+        endif()
+    
+    # 找到了就添加进变量里
+    else()
+        # 这里因为cmake无法储存list(list(str))，因此我们把list给合成一个str再APPEND进SYMS_TO_INSTALL，
+        # 之后要用时再拆回list。上面的opencv_world的处理方式也是一样的。输出的str长这样：
+        # "${OpenCV库普通文件名}/${OpenCV库符号链接名1}/${OpenCV库符号链接名2}/..."
+        
+        list(APPEND LIBS_TO_INSTALL ${opencv_core_regular})
+        list(JOIN opencv_core_symlink "/" opencv_core_symlink_str)
+        list(APPEND SYMS_TO_INSTALL ${opencv_core_symlink_str})
+        
+        list(APPEND LIBS_TO_INSTALL ${opencv_imgcodecs_regular})
+        list(JOIN opencv_imgcodecs_symlink "/" opencv_imgcodecs_symlink_str)
+        list(APPEND SYMS_TO_INSTALL ${opencv_imgcodecs_symlink_str})
+        
+        list(APPEND LIBS_TO_INSTALL ${opencv_imgproc_regular})
+        list(JOIN opencv_imgproc_symlink "/" opencv_imgproc_symlink_str)
+        list(APPEND SYMS_TO_INSTALL ${opencv_imgproc_symlink_str})
+    endif()
+endif()
+
+# 最后把所有要安装的共享库复制到TARGET的输出文件夹里
+# 在之后的安装环节会直接从这个文件夹安装
+foreach(ITEM ${LIBS_TO_INSTALL})
     add_custom_command(TARGET ${DEMO_NAME} POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_if_different
         ${ITEM}
@@ -399,6 +462,22 @@ else ()
         PATTERN "*${CMAKE_SHARED_LIBRARY_SUFFIX}*"
         PATTERN "${DEMO_NAME}*" EXCLUDE
     )
+    
+    # 创建共享库的符号链接
+    foreach(ITEM_STR ${SYMS_TO_INSTALL})
+        string(REPLACE "/" ";" ITEM_LIST ${ITEM_STR})
+        list(POP_FRONT ITEM_LIST ITEM_REGULAR_NAME)
+        foreach(ITEM_SYMLINK_NAME ${ITEM_LIST})
+            # 这里我们在 cmake_install.cmake 安装脚本里加入下面这行脚本：
+            # 进入到安装脚本环境里的 ${CMAKE_INSTALL_PREFIX}/lib 目录 
+            # 然后再创建符号链接
+            install(CODE "\
+                execute_process(COMMAND ${CMAKE_COMMAND} -E chdir \$\{CMAKE_INSTALL_PREFIX\}/lib \
+                ${CMAKE_COMMAND} -E create_symlink ${ITEM_REGULAR_NAME} ${ITEM_SYMLINK_NAME})"
+            )
+        endforeach()
+    endforeach()
+    
     if (INSTALL_WITH_TOOLS)
         # 安装启动脚本和安装脚本
         install(

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.15...3.30)
 # cmake version range:
 # https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html
+# https://github.com/jbeder/yaml-cpp/pull/1211#issuecomment-1681352550
 
 project(PaddleOCR-json CXX C)
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,7 +1,15 @@
-cmake_minimum_required(VERSION 3.15...3.30)
+# cmake_minimum_required(VERSION 3.15...3.30)
+cmake_minimum_required(VERSION 3.14)
+# 这里本来想给cmake_minimum_required设置一下版本范围，
+# 然后发现如果将cmake最低版本改成3.15时，Windows MSVC下会出现
+# 大量的链接错误，基本都是一些libc底层函数的unresolved external symbol
+# 和symbol redefinition错误。具体原因未知，即使把cmake 3.15的新policies
+# 给禁用了也没用。不知道是3.15的什么改动造成的。不过现在用3.14也没有问题。
+# 
 # cmake version range:
 # https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html
 # https://github.com/jbeder/yaml-cpp/pull/1211#issuecomment-1681352550
+
 
 project(PaddleOCR-json CXX C)
 
@@ -120,27 +128,20 @@ message(STATUS "    INSTALL_WITH_TOOLS: ${INSTALL_WITH_TOOLS}")
 # 请提供一个路径包含 "OpenCVConfig.cmake" 或 "opencv-config.cmake"这两个文件
 # 或者提供 OpenCV 编译后的安装目录
 
+set(OPENCV_COMPONENTS_TO_LOAD
+    core
+    imgproc
+    imgcodecs
+)
+
 # 由CMake参数提供（-DOPENCV_DIR）
 if(DEFINED OPENCV_DIR AND NOT "${OPENCV_DIR}" STREQUAL "")
     message(STATUS "Setting OPENCV_DIR: ${OPENCV_DIR}")
-    find_package(OpenCV PATHS ${OPENCV_DIR} NO_DEFAULT_PATH)
+    find_package(OpenCV REQUIRED PATHS ${OPENCV_DIR} COMPONENTS ${OPENCV_COMPONENTS_TO_LOAD} NO_DEFAULT_PATH)
     set(CUSTOM_OPENCV_DIR ${OPENCV_DIR})
-elseif(DEFINED OpenCV_DIR AND NOT "${OpenCV_DIR}" STREQUAL "")
-    message(STATUS "Setting OPENCV_DIR: ${OpenCV_DIR}")
-    find_package(OpenCV PATHS ${OpenCV_DIR} NO_DEFAULT_PATH)
-    set(CUSTOM_OPENCV_DIR ${OpenCV_DIR})
-# 由环境变量提供 OPENCV_DIR 或 OpenCV_DIR 提供
-elseif(NOT "$ENV{OPENCV_DIR}" STREQUAL "")
-    message(STATUS "Setting OPENCV_DIR: $ENV{OPENCV_DIR}")
-    find_package(OpenCV PATHS $ENV{OPENCV_DIR} NO_DEFAULT_PATH)
-    set(CUSTOM_OPENCV_DIR $ENV{OPENCV_DIR})
-elseif(NOT "$ENV{OpenCV_DIR}" STREQUAL "")
-    message(STATUS "Setting OPENCV_DIR: $ENV{OpenCV_DIR}")
-    find_package(OpenCV PATHS $ENV{OpenCV_DIR} NO_DEFAULT_PATH)
-    set(CUSTOM_OPENCV_DIR $ENV{OpenCV_DIR})
 # 没有提供OpenCV路径，尝试让CMake自己寻找
 else()
-    find_package(OpenCV REQUIRED)
+    find_package(OpenCV REQUIRED COMPONENTS ${OPENCV_COMPONENTS_TO_LOAD})
 endif()
 include_directories(${OpenCV_INCLUDE_DIRS})
 
@@ -331,11 +332,9 @@ if (NOT WIN32)
     set(DEPS ${DEPS} ${EXTERNAL_LIB})
 endif()
 
-set(DEPS ${DEPS}
-    opencv_core
-    opencv_imgcodecs
-    opencv_imgproc
-)
+# 在find_package时已经指定了需要加载的模块，
+# 这里直接用OpenCV_LIBS就行了
+set(DEPS ${DEPS} ${OpenCV_LIBS})
 
 include(FetchContent)
 include(external-cmake/auto-log.cmake)
@@ -377,6 +376,7 @@ if(DEFINED CUSTOM_OPENCV_DIR AND NOT "${CUSTOM_OPENCV_DIR}" STREQUAL "")
         if(opencv_world_miss_lib)
             message(FATAL_ERROR "Cannot find OpenCV independent shared libraries or opencv_world. Please make sure your custom OpenCV directory contains the missing libraries.")
         else()
+            message(STATUS "Found opencv_world")
             list(APPEND LIBS_TO_INSTALL ${opencv_world_regular})
             list(JOIN opencv_world_symlink "/" opencv_world_symlink_str)
             list(APPEND SYMS_TO_INSTALL ${opencv_world_symlink_str})
@@ -418,20 +418,20 @@ endforeach()
 # https://github.com/opencv/opencv/blob/a03b81316782ae30038b288fd3568993fa1e3538/CMakeLists.txt#L141-L152
 # https://cmake.org/cmake/help/latest/variable/CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT.html
 # 如果CMake安装路径为默认
-if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     # 本地编译
-    if (NOT CMAKE_TOOLCHAIN_FILE)
-        if (WIN32)
+    if(NOT CMAKE_TOOLCHAIN_FILE)
+        if(WIN32)
             set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install" CACHE PATH "安装路径" FORCE)
-        else ()
+        else()
             set(CMAKE_INSTALL_PREFIX "/usr/" CACHE PATH "安装路径" FORCE)
-        endif ()
+        endif()
     
     # 其他跨平台编译
-    else ()
+    else()
         set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install" CACHE PATH "安装路径" FORCE)
-    endif ()
-endif ()
+    endif()
+endif()
 
 # 设置安装文件的运行环境路径
 set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
@@ -445,7 +445,7 @@ install(
     RUNTIME DESTINATION "bin"
 )
 # 其他安装
-if (WIN32)
+if(WIN32)
     # 安装共享库
     install(
         DIRECTORY "$<TARGET_FILE_DIR:${DEMO_NAME}>/"
@@ -454,7 +454,7 @@ if (WIN32)
         PATTERN "*${CMAKE_SHARED_LIBRARY_SUFFIX}*"
         PATTERN "${DEMO_NAME}*" EXCLUDE
     )
-else ()
+else()
     # 安装共享库
     install(
         DIRECTORY "$<TARGET_FILE_DIR:${DEMO_NAME}>/"
@@ -467,7 +467,14 @@ else ()
     # 创建共享库的符号链接
     foreach(ITEM_STR ${SYMS_TO_INSTALL})
         string(REPLACE "/" ";" ITEM_LIST ${ITEM_STR})
-        list(POP_FRONT ITEM_LIST ITEM_REGULAR_NAME)
+        
+        # 这里本来想用cmake 3.15的list(POP_FRONT)功能的，
+        # 不过将cmake最低版本要求提到3.15会出现大量链接错误（详情请看文件顶部）
+        # 于是就用一套旧的API来实现了
+        # list(POP_FRONT ITEM_LIST ITEM_REGULAR_NAME)
+        list(GET ITEM_LIST 0 ITEM_REGULAR_NAME)
+        list(REMOVE_AT ITEM_LIST 0)
+        
         foreach(ITEM_SYMLINK_NAME ${ITEM_LIST})
             # 这里我们在 cmake_install.cmake 安装脚本里加入下面这行脚本：
             # 进入到安装脚本环境里的 ${CMAKE_INSTALL_PREFIX}/lib 目录 
@@ -495,5 +502,5 @@ else ()
             PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ GROUP_WRITE WORLD_READ
             DESTINATION "."
         )
-    endif ()
-endif ()
+    endif()
+endif()

--- a/cpp/README-linux.md
+++ b/cpp/README-linux.md
@@ -284,7 +284,8 @@ cmake --build build/
 | `TENSORRT_DIR` | 使用TensorRT编译并设置其路径 |
 
 > [!NOTE]
-> * `OPENCV_DIR`: Linux下，如果已经安装到系统之中就不用指定了。
+> * 您也可以通过设置环境变量 `OpenCV_DIR` 来设置OpenCV库的路径，注意变量名大小写敏感。
+> * `OPENCV_DIR` 或环境变量: Linux下，如果已经安装到系统之中就不用指定了。
 
 以下是一些PaddleOCR-json功能相关参数。
 

--- a/cpp/README-linux.md
+++ b/cpp/README-linux.md
@@ -42,6 +42,9 @@ Flags:                              fpu vme de pse tsc msr pae mce cx8 apic sep 
 > 如果你的CPU不支持AVX指令集，我们建议你尝试隔壁的[RapidOCR-json](https://github.com/hiroi-sora/RapidOCR-json)
 >
 > 当然，你也可以更换一个不需要AVX指令集的预测库来编译PaddleOCR-json（比如 `manylinux_cpu_noavx_openblas_gcc8.2` ）。不过大概率运行不了。
+> 
+> 如果你执意要使用无AVX指令集的预测库来编译PaddleOCR-json，编译、运行时遇到问题大概率为预测库不兼容，此时可以优先去[PaddleOCR官方的仓库看看](https://github.com/PaddlePaddle/PaddleOCR/issues)
+> * 如果你遇到了`核心已转储（core dump）`的报错，也可以看看[这个issue](https://github.com/hiroi-sora/PaddleOCR-json/issues/170)
 
 ### 1.1 安装所需工具
 

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -67,7 +67,7 @@ Where to build the binaries: `……/PaddleOCR-json/cpp/build`
 
 2. 填写三项配置：
 
-OPENCV_DIR 和 OpenCV_DIR:  
+OPENCV_DIR 或 OpenCV_DIR:  
 `……/PaddleOCR-json/cpp/.source/opencv/build/x64/vc16/lib`
 
 PADDLE_LIB:  

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -65,9 +65,9 @@ Where to build the binaries: `……/PaddleOCR-json/cpp/build`
 执行完会报错，很正常，点OK。
 ![](docs/imgs/b2.png)
 
-2. 填写三项配置：
+2. 填写两项配置：
 
-OPENCV_DIR 或 OpenCV_DIR:  
+OPENCV_DIR:  
 `……/PaddleOCR-json/cpp/.source/opencv/build/x64/vc16/lib`
 
 PADDLE_LIB:  
@@ -105,6 +105,9 @@ PADDLE_LIB:
 | `CUDA_LIB`     | 库的路径                     |
 | `CUDNN_LIB`    | 库的路径                     |
 | `TENSORRT_DIR` | 使用TensorRT编译并设置其路径 |
+
+> [!NOTE]
+> * 您也可以通过设置环境变量 `OpenCV_DIR` 来设置OpenCV库的路径，注意变量名大小写敏感。
 
 以下是一些PaddleOCR-json功能相关参数。
 

--- a/cpp/cmake/opencv-install-utils.cmake
+++ b/cpp/cmake/opencv-install-utils.cmake
@@ -1,0 +1,50 @@
+# OpenCV 安装工具函数
+
+# collect_opencv_lib()
+# @参数
+#   in_opencv_lib_dir               [输入][str]  用户输入的 OPENCV_DIR
+#   in_cmake_shared_lib_suffix      [输入][str]  CMAKE_SHARED_LIBRARY_SUFFIX
+#   in_opencv_lib_name              [输入][str]  当前链接的OpenCV库名，如 opencv_core、opencv_imgcodecs
+#   out_opencv_miss_lib             [输出][bool] 是否找到了输入的OpenCV库文件
+#   out_opencv_lib_regular_file     [输出][str]  找到的OpenCV库普通文件绝对路径
+#   out_opencv_lib_symlink          [输出][list] 找到的OpenCV库普通文件与库符号链接名，用于后续创建符号链接
+macro(collect_opencv_lib
+        in_opencv_lib_dir
+        in_cmake_shared_lib_suffix
+        in_opencv_lib_name
+        out_opencv_miss_lib
+        out_opencv_lib_regular_file
+        out_opencv_lib_symlink
+    )
+    # 寻找库文件
+    file(GLOB_RECURSE __opencv_libs_found "${in_opencv_lib_dir}/**/*${in_opencv_lib_name}*${in_cmake_shared_lib_suffix}*")
+    
+    # 检查是否找到
+    if("${__opencv_libs_found}" STREQUAL "")
+        message(WARNING "Missing independent shared library: ${in_opencv_lib_name}")
+        set(${out_opencv_miss_lib} TRUE)
+    endif()
+    
+    # 拆分普通文件与符号链接
+    foreach(__item ${__opencv_libs_found})
+        if(IS_SYMLINK ${__item})
+            get_filename_component(__item_name ${__item} NAME)
+            list(APPEND __symlink_libs ${__item_name})
+        else()
+            set(__regular_libs ${__item})
+        endif()
+    endforeach()
+    
+    # 输出
+    set(${out_opencv_lib_regular_file} ${__regular_libs})
+    get_filename_component(__regular_libs_name ${__regular_libs} NAME)
+    set(${out_opencv_lib_symlink} ${__regular_libs_name} ${__symlink_libs})
+    
+    # 清理缓存的变量
+    unset(__opencv_libs_found)
+    unset(__item)
+    unset(__item_name)
+    unset(__symlink_libs)
+    unset(__regular_libs)
+    unset(__regular_libs_name)
+endmacro(collect_opencv_lib)

--- a/cpp/cmake/opencv-install-utils.cmake
+++ b/cpp/cmake/opencv-install-utils.cmake
@@ -21,7 +21,7 @@ macro(collect_opencv_lib
     
     # 检查是否找到
     if("${__opencv_libs_found}" STREQUAL "")
-        message(WARNING "Missing independent shared library: ${in_opencv_lib_name}")
+        message(STATUS "Missing independent shared library: ${in_opencv_lib_name}")
         set(${out_opencv_miss_lib} TRUE)
     endif()
     
@@ -37,8 +37,10 @@ macro(collect_opencv_lib
     
     # 输出
     set(${out_opencv_lib_regular_file} ${__regular_libs})
-    get_filename_component(__regular_libs_name ${__regular_libs} NAME)
-    set(${out_opencv_lib_symlink} ${__regular_libs_name} ${__symlink_libs})
+    if(DEFINED __symlink_libs AND NOT "${__symlink_libs}" STREQUAL "")
+        get_filename_component(__regular_libs_name "${__regular_libs}" NAME)
+        set(${out_opencv_lib_symlink} ${__regular_libs_name} ${__symlink_libs})
+    endif()
     
     # 清理缓存的变量
     unset(__opencv_libs_found)


### PR DESCRIPTION
* 修复当用户手动指定OPENCV_DIR时cmake --install命令无法安装opencv动态库
    * 现在cmake会在linux安装/打包时自动创建opencv动态库的符号链接，因此压缩时需要注意保留。
* 更新cmake post build复制文件命令，确保其找到所有的依赖库 (#168)
    * 这算是个guess fix，因为旧的实现已经会递归寻找路径下所有的库文件了，不确定为什么会出现问题。不过修改后也不会造成什么影响
* ~~把cmake_minimum_required的最低版本要求提到3.15，为了使用[list(POP_FRONT)](https://cmake.org/cmake/help/latest/command/list.html#pop-front)。同时为其添加了一个版本范围，具体可以看看这两篇文章~~
    * https://github.com/jbeder/yaml-cpp/pull/1211#issuecomment-1681352550
    * https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html
* 保持cmake_minimum_required不变，**如果将cmake最低版本或者cmake policy最高版本提到 >= 3.15 之后，Windows MSVC下就会出现大量的链接错误。** 基本都是一些libc底层函数的unresolved external symbol和symbol redefinition错误。具体原因未知，即使把cmake 3.15的新policies给禁用了也没用。不知道是3.15的什么改动造成的。不过现在用3.14也没有问题。
    * 对目前的cmake安装要求没有影响，只要是 >= 3.14的cmake就行了
* 移除了cmake里多余的opencv参数。把cmake参数`-DOpenCV_DIR`以及环境变量`OpenCV_DIR`和`OPENCV_DIR`移除，只保留参数`-DOPENCV_DIR`。这些多余的参数和环境变量会与opencv的cmake脚本冲突。（用的也不多）
* 更新文档